### PR TITLE
Support custom extensions

### DIFF
--- a/webauthn-authenticator-rs/examples/authenticate.rs
+++ b/webauthn-authenticator-rs/examples/authenticate.rs
@@ -3,7 +3,7 @@ extern crate tracing;
 
 #[cfg(feature = "softtoken")]
 use std::fs::OpenOptions;
-use std::io::{stdin, stdout, Write};
+use std::{collections::BTreeMap, io::{stdin, stdout, Write}};
 use std::time::Duration;
 
 use clap::clap_derive::ValueEnum;
@@ -286,6 +286,7 @@ async fn main() {
                     appid: Some("example.app.id".to_string()),
                     uvm: None,
                     hmac_get_secret: None,
+                    custom: BTreeMap::new() 
                 }))
             })
             .and_then(|b| wan.generate_challenge_authenticate(b))

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -215,7 +215,9 @@ pub(crate) fn process_authentication_extensions(
     auth_extn: &AuthenticationSignedExtensions,
 ) -> AuthenticationExtensions {
     trace!(?auth_extn);
-    AuthenticationExtensions {}
+    AuthenticationExtensions {
+        unknown_keys: auth_extn.unknown_keys.clone()
+    }
 }
 
 /*

--- a/webauthn-rs-proto/Cargo.toml
+++ b/webauthn-rs-proto/Cargo.toml
@@ -28,6 +28,7 @@ base64urlsafedata.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 url = { workspace = true, features = ["serde"] }
+serde_cbor_2.workspace = true
 # num_enum = "0.5"
 
 # Webauthn Components

--- a/webauthn-rs-proto/src/extensions.rs
+++ b/webauthn-rs-proto/src/extensions.rs
@@ -184,6 +184,10 @@ pub struct RequestAuthenticationExtensions {
     /// Hmac get secret
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hmac_get_secret: Option<HmacGetSecretInput>,
+    
+    /// Custom extensions
+    #[serde(flatten)]
+    pub custom: BTreeMap<String, serde_cbor_2::Value> 
 }
 
 // Unable to create from, because it's an out of crate struct
@@ -199,6 +203,7 @@ impl Into<js_sys::Object> for &RequestAuthenticationExtensions {
             appid: _,
             uvm,
             hmac_get_secret,
+            custom: _
         } = self;
 
         let obj = Object::new();

--- a/webauthn-rs-proto/src/extensions.rs
+++ b/webauthn-rs-proto/src/extensions.rs
@@ -1,5 +1,7 @@
 //! Extensions allowing certain types of authenticators to provide supplemental information.
 
+use std::collections::BTreeMap;
+
 use base64urlsafedata::Base64UrlSafeData;
 use serde::{Deserialize, Serialize};
 
@@ -414,4 +416,8 @@ impl RegisteredExtensions {
 
 /// The set of extensions that were provided by the client during authentication
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AuthenticationExtensions {}
+pub struct AuthenticationExtensions {
+    /// Custom extensions 
+    #[serde(flatten)]
+    pub unknown_keys: BTreeMap<String, serde_cbor_2::Value>,
+}

--- a/webauthn-rs/Cargo.toml
+++ b/webauthn-rs/Cargo.toml
@@ -36,6 +36,7 @@ url = { workspace = true, features = ["serde"] }
 tracing.workspace = true
 serde.workspace = true
 uuid = { workspace = true, features = ["v4", "serde"] }
+serde_cbor_2.workspace = true
 
 [dev-dependencies]
 webauthn-rs-device-catalog.workspace = true

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -348,7 +348,8 @@ pub struct SecurityKeyRegistration {
     derive(Serialize, Deserialize)
 )]
 pub struct SecurityKeyAuthentication {
-    pub(crate) ast: AuthenticationState,
+    /// Made public so we can can call set_allowed_credentials on its interior type
+    pub ast: AuthenticationState,
 }
 
 /// A Security Key for a user. These are the legacy "second factor" method of security tokens.

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -190,7 +190,7 @@ extern crate tracing;
 
 mod interface;
 
-use std::time::Duration;
+use std::{collections::BTreeMap, time::Duration};
 use url::Url;
 use uuid::Uuid;
 use webauthn_rs_core::error::{WebauthnError, WebauthnResult};
@@ -999,6 +999,47 @@ impl Webauthn {
     ) -> WebauthnResult<AuthenticationResult> {
         self.core.authenticate_credential(reg, &state.ast)
     }
+
+    /// Given a set of [SecurityKey], begin an authentication of the user. This returns
+    /// a `RequestChallengeResponse`, which should be serialised to json and sent to the user agent (e.g. a browser).
+    /// The server must persist the [SecurityKeyAuthentication] state as it is paired to the
+    /// `RequestChallengeResponse` and required to complete the authentication.
+    ///
+    /// Finally you need to call [`finish_securitykey_authentication`](Webauthn::finish_securitykey_authentication)
+    /// to complete the authentication.
+    ///
+    /// WARNING ⚠️  YOU MUST STORE THE [SecurityKeyAuthentication] VALUE SERVER SIDE.
+    ///
+    /// Failure to do so *may* open you to replay attacks which can significantly weaken the
+    /// security of this system.
+    pub fn start_securitykey_with_custom_extensions_authentication(
+        &self,
+        creds: &[SecurityKey],
+        custom: Option<BTreeMap<String, serde_cbor_2::Value>>
+    ) -> WebauthnResult<(RequestChallengeResponse, SecurityKeyAuthentication)> {
+        let extensions = custom.map(|custom| RequestAuthenticationExtensions { appid: None, uvm: None, hmac_get_secret: None, custom });
+        let creds = creds.iter().map(|sk| sk.cred.clone()).collect();
+        let allow_backup_eligible_upgrade = false;
+
+        let policy = if self.user_presence_only_security_keys {
+            Some(UserVerificationPolicy::Discouraged_DO_NOT_USE)
+        } else {
+            Some(UserVerificationPolicy::Preferred)
+        };
+
+        let hints = Some(vec![PublicKeyCredentialHints::SecurityKey]);
+
+        self.core
+            .new_challenge_authenticate_builder(creds, policy)
+            .map(|builder| {
+                builder
+                    .extensions(extensions)
+                    .allow_backup_eligible_upgrade(allow_backup_eligible_upgrade)
+                    .hints(hints)
+            })
+            .and_then(|b| self.core.generate_challenge_authenticate(b))
+            .map(|(rcr, ast)| (rcr, SecurityKeyAuthentication { ast }))
+    }
 }
 
 #[cfg(any(all(doc, not(doctest)), feature = "attestation"))]
@@ -1256,6 +1297,7 @@ impl Webauthn {
             appid: None,
             uvm: Some(true),
             hmac_get_secret: None,
+            custom: BTreeMap::new() 
         });
 
         let policy = Some(UserVerificationPolicy::Required);
@@ -1323,6 +1365,7 @@ impl Webauthn {
             appid: None,
             uvm: Some(true),
             hmac_get_secret: None,
+            custom: BTreeMap::new() 
         });
         let allow_backup_eligible_upgrade = false;
         let hints = None;
@@ -1500,6 +1543,7 @@ impl Webauthn {
             appid: None,
             uvm: Some(true),
             hmac_get_secret: None,
+            custom: BTreeMap::new() 
         });
 
         let policy = Some(UserVerificationPolicy::Required);


### PR DESCRIPTION
Supercedes #3 when #4 replaces the current `master`.

Currently hardcodes the hint to security key which matches the current webflow functionality. We'll want that to be adjustable when we use the native webauthn prompts for other auth factors.