### PR TITLE
Parameterize hints in registration and authentication for passkeys and security keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ webauthn-rs-demo-wasm/pkg
 local
 build.sh
 .direnv
+.idea

--- a/webauthn-rs-core/src/internals.rs
+++ b/webauthn-rs-core/src/internals.rs
@@ -187,19 +187,19 @@ impl Credential {
         let backup_eligible = auth_data.backup_eligible;
         let backup_state = auth_data.backup_state;
 
-        let transports = if attestation_format == AttestationFormat::Packed
-            || attestation_format == AttestationFormat::Tpm
-        {
-            transports.clone()
-        } else {
-            None
-        };
+        // let transports = if attestation_format == AttestationFormat::Packed
+        //     || attestation_format == AttestationFormat::Tpm
+        // {
+        //     transports.clone()
+        // } else {
+        //     None
+        // };
 
         Credential {
             cred_id: acd.credential_id.clone(),
             cred: ck,
             counter,
-            transports,
+            transports: transports.clone(),
             user_verified,
             backup_eligible,
             backup_state,

--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -269,7 +269,7 @@ pub enum AuthenticatorAttachment {
 ///
 /// <https://www.w3.org/TR/webauthn-3/#enumdef-publickeycredentialhints>
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 #[allow(unused)]
 pub enum PublicKeyCredentialHints {
     /// The credential is a removable security key

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -41,7 +41,8 @@ pub struct PasskeyRegistration {
     derive(Serialize, Deserialize)
 )]
 pub struct PasskeyAuthentication {
-    pub(crate) ast: AuthenticationState,
+    // Make public so we can call set_allowed_credentials on its interior type
+    pub ast: AuthenticationState,
 }
 
 /// A Passkey for a user. A passkey is a term that covers all possible authenticators that may exist.

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -41,7 +41,7 @@ pub struct PasskeyRegistration {
     derive(Serialize, Deserialize)
 )]
 pub struct PasskeyAuthentication {
-    // Make public so we can call set_allowed_credentials on its interior type
+    /// Make public so we can call set_allowed_credentials on its interior type
     pub ast: AuthenticationState,
 }
 

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -587,7 +587,8 @@ impl Webauthn {
         user_display_name: &str,
         exclude_credentials: Option<Vec<CredentialID>>,
         hints: Option<Vec<PublicKeyCredentialHints>>,
-        ui_hint_authenticator_attachment: Option<AuthenticatorAttachment>
+        ui_hint_authenticator_attachment: Option<AuthenticatorAttachment>,
+        require_resident_key: bool,
     ) -> WebauthnResult<(CreationChallengeResponse, PasskeyRegistration)> {
         let extensions = Some(RequestRegistrationExtensions {
             cred_protect: Some(CredProtect {
@@ -614,7 +615,7 @@ impl Webauthn {
             )?
             .attestation(AttestationConveyancePreference::None)
             .credential_algorithms(self.algorithms.clone())
-            .require_resident_key(true)
+            .require_resident_key(require_resident_key)
             .authenticator_attachment(ui_hint_authenticator_attachment)
             .user_verification_policy(UserVerificationPolicy::Required)
             .reject_synchronised_authenticators(false)

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -614,7 +614,7 @@ impl Webauthn {
             )?
             .attestation(AttestationConveyancePreference::None)
             .credential_algorithms(self.algorithms.clone())
-            .require_resident_key(false)
+            .require_resident_key(true)
             .authenticator_attachment(ui_hint_authenticator_attachment)
             .user_verification_policy(UserVerificationPolicy::Required)
             .reject_synchronised_authenticators(false)

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -577,6 +577,56 @@ impl Webauthn {
             .map(|(ccr, rs)| (ccr, PasskeyRegistration { rs }))
     }
 
+    /// Passkey registration, but with exposed parameters for hints and 
+    /// authenticator attachment, allowing customization of restrictions regarding
+    /// passkey vs platform authenticators.
+    pub fn start_passkey_registration2(
+        &self,
+        user_unique_id: Uuid,
+        user_name: &str,
+        user_display_name: &str,
+        exclude_credentials: Option<Vec<CredentialID>>,
+        hints: Option<Vec<PublicKeyCredentialHints>>,
+        ui_hint_authenticator_attachment: Option<AuthenticatorAttachment>
+    ) -> WebauthnResult<(CreationChallengeResponse, PasskeyRegistration)> {
+        let extensions = Some(RequestRegistrationExtensions {
+            cred_protect: Some(CredProtect {
+                // Since this may contain PII, we want to enforce this. We also
+                // want the device to strictly enforce its UV state.
+                credential_protection_policy: CredentialProtectionPolicy::UserVerificationRequired,
+                // If set to true, causes many authenticators to shit the bed. We have to just hope
+                // and pray instead. This is because many device classes when they see this extension
+                // and can't satisfy it, they fail the operation instead.
+                enforce_credential_protection_policy: Some(false),
+            }),
+            uvm: Some(true),
+            cred_props: Some(true),
+            min_pin_length: None,
+            hmac_create_secret: None,
+        });
+
+        let builder = self
+            .core
+            .new_challenge_register_builder(
+                user_unique_id.as_bytes(),
+                user_name,
+                user_display_name,
+            )?
+            .attestation(AttestationConveyancePreference::None)
+            .credential_algorithms(self.algorithms.clone())
+            .require_resident_key(false)
+            .authenticator_attachment(ui_hint_authenticator_attachment)
+            .user_verification_policy(UserVerificationPolicy::Required)
+            .reject_synchronised_authenticators(false)
+            .exclude_credentials(exclude_credentials)
+            .hints(hints)
+            .extensions(extensions);
+
+        self.core
+            .generate_challenge_register(builder)
+            .map(|(ccr, rs)| (ccr, PasskeyRegistration { rs }))
+    }
+
     /// Initiate the registration of a 'Google Passkey stored in Google Password Manager' on an
     /// Android device with GMS Core.
     ///
@@ -693,6 +743,31 @@ impl Webauthn {
             .and_then(|b| self.core.generate_challenge_authenticate(b))
             .map(|(rcr, ast)| (rcr, PasskeyAuthentication { ast }))
     }
+
+    /// Passkey authentication with exposed hints allowing targeting of either 
+    /// passkeys or platform authenticators.
+    pub fn start_passkey_authentication2(
+        &self,
+        creds: &[Passkey],
+        hints: Option<Vec<PublicKeyCredentialHints>>
+    ) -> WebauthnResult<(RequestChallengeResponse, PasskeyAuthentication)> {
+        let extensions = None;
+        let creds = creds.iter().map(|sk| sk.cred.clone()).collect();
+        let policy = Some(UserVerificationPolicy::Required);
+        let allow_backup_eligible_upgrade = true;
+
+        self.core
+            .new_challenge_authenticate_builder(creds, policy)
+            .map(|builder| {
+                builder
+                    .extensions(extensions)
+                    .allow_backup_eligible_upgrade(allow_backup_eligible_upgrade)
+                    .hints(hints)
+            })
+            .and_then(|b| self.core.generate_challenge_authenticate(b))
+            .map(|(rcr, ast)| (rcr, PasskeyAuthentication { ast }))
+    }
+    
 
     /// Given the `PublicKeyCredential` returned by the user agent (e.g. a browser), and the stored [PasskeyAuthentication]
     /// complete the authentication of the user.
@@ -910,6 +985,85 @@ impl Webauthn {
             })
     }
 
+    /// Security key registration with hints exposed, 
+    /// allowing categorization of security keys vs unspecified webauthn devices.
+    #[allow(clippy::too_many_arguments)]
+    pub fn start_securitykey_registration2(
+        &self,
+        user_unique_id: Uuid,
+        user_name: &str,
+        user_display_name: &str,
+        exclude_credentials: Option<Vec<CredentialID>>,
+        attestation_ca_list: Option<AttestationCaList>,
+        ui_hint_authenticator_attachment: Option<AuthenticatorAttachment>,
+        hints: Option<Vec<PublicKeyCredentialHints>>
+    ) -> WebauthnResult<(CreationChallengeResponse, SecurityKeyRegistration)> {
+        let attestation = if let Some(ca_list) = attestation_ca_list.as_ref() {
+            if ca_list.is_empty() {
+                return Err(WebauthnError::MissingAttestationCaList);
+            } else {
+                AttestationConveyancePreference::Direct
+            }
+        } else {
+            AttestationConveyancePreference::None
+        };
+
+        let cred_protect = if self.user_presence_only_security_keys {
+            None
+        } else {
+            Some(CredProtect {
+                // We want the device to strictly enforce its UV state.
+                credential_protection_policy: CredentialProtectionPolicy::UserVerificationRequired,
+                // If set to true, causes many authenticators to shit the bed. Since this type doesn't
+                // have the same strict rules about attestation, then we just use this opportunistically.
+                enforce_credential_protection_policy: Some(false),
+            })
+        };
+
+        let extensions = Some(RequestRegistrationExtensions {
+            cred_protect,
+            uvm: Some(true),
+            cred_props: Some(true),
+            min_pin_length: None,
+            hmac_create_secret: None,
+        });
+
+        let policy = if self.user_presence_only_security_keys {
+            UserVerificationPolicy::Discouraged_DO_NOT_USE
+        } else {
+            UserVerificationPolicy::Preferred
+        };
+
+        let builder = self
+            .core
+            .new_challenge_register_builder(
+                user_unique_id.as_bytes(),
+                user_name,
+                user_display_name,
+            )?
+            .attestation(attestation)
+            .credential_algorithms(self.algorithms.clone())
+            .require_resident_key(false)
+            .authenticator_attachment(ui_hint_authenticator_attachment)
+            .user_verification_policy(policy)
+            .reject_synchronised_authenticators(false)
+            .exclude_credentials(exclude_credentials)
+            .hints(hints)
+            .extensions(extensions);
+
+        self.core
+            .generate_challenge_register(builder)
+            .map(|(ccr, rs)| {
+                (
+                    ccr,
+                    SecurityKeyRegistration {
+                        rs,
+                        ca_list: attestation_ca_list,
+                    },
+                )
+            })
+    }
+
     /// Complete the registration of the credential. The user agent (e.g. a browser) will return the data of `RegisterPublicKeyCredential`,
     /// and the server provides its paired [SecurityKeyRegistration]. The details of the Authenticator
     /// based on the registration parameters are asserted.
@@ -1015,9 +1169,10 @@ impl Webauthn {
     pub fn start_securitykey_with_custom_extensions_authentication(
         &self,
         creds: &[SecurityKey],
-        custom: Option<BTreeMap<String, serde_cbor_2::Value>>
+        hints: Option<Vec<PublicKeyCredentialHints>>,
+        custom_extensions: Option<BTreeMap<String, serde_cbor_2::Value>>
     ) -> WebauthnResult<(RequestChallengeResponse, SecurityKeyAuthentication)> {
-        let extensions = custom.map(|custom| RequestAuthenticationExtensions { appid: None, uvm: None, hmac_get_secret: None, custom });
+        let extensions = custom_extensions.map(|custom| RequestAuthenticationExtensions { appid: None, uvm: None, hmac_get_secret: None, custom });
         let creds = creds.iter().map(|sk| sk.cred.clone()).collect();
         let allow_backup_eligible_upgrade = true;
 
@@ -1026,8 +1181,6 @@ impl Webauthn {
         } else {
             Some(UserVerificationPolicy::Preferred)
         };
-
-        let hints = None;
 
         self.core
             .new_challenge_authenticate_builder(creds, policy)


### PR DESCRIPTION
Opting to define new functions so as to not collide with any upstream changes directly.