### PR TITLE
Support Security Keys SubTypes

### DIFF
--- a/webauthn-rs-proto/src/options.rs
+++ b/webauthn-rs-proto/src/options.rs
@@ -269,7 +269,7 @@ pub enum AuthenticatorAttachment {
 ///
 /// <https://www.w3.org/TR/webauthn-3/#enumdef-publickeycredentialhints>
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 #[allow(unused)]
 pub enum PublicKeyCredentialHints {
     /// The credential is a removable security key

--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -41,7 +41,8 @@ pub struct PasskeyRegistration {
     derive(Serialize, Deserialize)
 )]
 pub struct PasskeyAuthentication {
-    pub(crate) ast: AuthenticationState,
+    // Make public so we can call set_allowed_credentials on its interior type
+    pub ast: AuthenticationState,
 }
 
 /// A Passkey for a user. A passkey is a term that covers all possible authenticators that may exist.


### PR DESCRIPTION
1. Make passkeyauthentication.ast public so that we can call set_allowed_credentials on its interior type
2. Use kebab-case for PublicKeyCredentialHints instead of lowercase based on https://opotonniee.github.io/webauthn-playground/