### PR TITLE
Passkey to support only cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ webauthn-rs-demo-wasm/pkg
 local
 build.sh
 .direnv
+.idea

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -614,7 +614,7 @@ impl Webauthn {
             )?
             .attestation(AttestationConveyancePreference::None)
             .credential_algorithms(self.algorithms.clone())
-            .require_resident_key(false)
+            .require_resident_key(true)
             .authenticator_attachment(ui_hint_authenticator_attachment)
             .user_verification_policy(UserVerificationPolicy::Required)
             .reject_synchronised_authenticators(false)


### PR DESCRIPTION
The existing changes in #7 wasn't setup to honoring/triggering cloud passkey hints. This update fixes that. I read up how to pass that specific hint [here](https://github.com/kanidm/webauthn-rs/issues/365#issuecomment-1756605203). In conjunction to this i have changed `start_passkey_registration2` `ui_hint_authenticator_attachment` param to be `AuthenticatorAttachment::Platform`


![image](https://github.com/user-attachments/assets/995c9367-a556-4d44-a5f8-a607a503e969)

