### PR TITLE
Create require resident key function parameter

### DIFF
--- a/webauthn-rs/src/interface.rs
+++ b/webauthn-rs/src/interface.rs
@@ -41,7 +41,7 @@ pub struct PasskeyRegistration {
     derive(Serialize, Deserialize)
 )]
 pub struct PasskeyAuthentication {
-    // Make public so we can call set_allowed_credentials on its interior type
+    /// Make public so we can call set_allowed_credentials on its interior type
     pub ast: AuthenticationState,
 }
 

--- a/webauthn-rs/src/lib.rs
+++ b/webauthn-rs/src/lib.rs
@@ -587,7 +587,8 @@ impl Webauthn {
         user_display_name: &str,
         exclude_credentials: Option<Vec<CredentialID>>,
         hints: Option<Vec<PublicKeyCredentialHints>>,
-        ui_hint_authenticator_attachment: Option<AuthenticatorAttachment>
+        ui_hint_authenticator_attachment: Option<AuthenticatorAttachment>,
+        require_resident_key: bool,
     ) -> WebauthnResult<(CreationChallengeResponse, PasskeyRegistration)> {
         let extensions = Some(RequestRegistrationExtensions {
             cred_protect: Some(CredProtect {
@@ -614,7 +615,7 @@ impl Webauthn {
             )?
             .attestation(AttestationConveyancePreference::None)
             .credential_algorithms(self.algorithms.clone())
-            .require_resident_key(true)
+            .require_resident_key(require_resident_key)
             .authenticator_attachment(ui_hint_authenticator_attachment)
             .user_verification_policy(UserVerificationPolicy::Required)
             .reject_synchronised_authenticators(false)


### PR DESCRIPTION
The fix in #10 broke authenticator passkey registration. This fixes the registration by moving require_resident_key as a function parameter rather than being hardcoded.

Authenticator registration
```
webauthn.start_passkey_registration2(
            person.uuid.into_uuid(),
            person.username.clone().into_inner().as_str(),
            SafeToDisplay(person.display_name()).to_string().as_str(),
            Some(existing_credentials),
            Some(vec![PublicKeyCredentialHints::ClientDevice]),
            Some(AuthenticatorAttachment::Platform),
            false,
        )?
```
<br/>

Cloud passkey registration
```
webauthn.start_passkey_registration2(
            person.uuid.into_uuid(),
            person.username.clone().into_inner().as_str(),
            SafeToDisplay(person.display_name()).to_string().as_str(),
            Some(existing_credentials),
            Some(vec![PublicKeyCredentialHints::Hybrid]),
            Some(AuthenticatorAttachment::Platform),
            true,
        )?
```
